### PR TITLE
login route for owner and walker created

### DIFF
--- a/controllers/api/owner-routes.js
+++ b/controllers/api/owner-routes.js
@@ -74,7 +74,32 @@ router.post('/', async (req, res) => {
   }
 });
 
-// POST api/owners/login route requires.
+/* POST api/owners/login route. looking for username and password in the db and verify it. Test: doesn't hash seed data password. only works on new user that had been created.
+Will look into bcrypt documentation for how to make seed password testable.*/
+router.post('/login', async (req, res) => {
+  try {
+    const ownerUserNameData = await Owner.findOne({
+      where: { user_name: req.body.user_name },
+    });
+    if (!ownerUserNameData) {
+      res.status(400).json({ message: 'No dog owner with that username!' });
+      return;
+    }
+    // verify the user using checkPassword method defined in Owner model.
+    const validPassword = ownerUserNameData.checkPassword(req.body.password);
+    if (!validPassword) {
+      res.status(400).json({ message: 'Invalid password. Try again' });
+      return;
+    }
+    res.json({
+      user: ownerUserNameData,
+      message: `${ownerUserNameData.owner_name}, you are now logged in!`,
+    });
+  } catch (err) {
+    console.log(err);
+    res.status(500).json(err);
+  }
+});
 
 // PUT api/owners/:id updating a owner's info based on its id.
 router.put('/:id', async (req, res) => {

--- a/controllers/api/walker-routes.js
+++ b/controllers/api/walker-routes.js
@@ -74,7 +74,31 @@ router.post('/', async (req, res) => {
   }
 });
 
-// POST api/walkers/login route requires.
+// POST api/walkers/login route. looking for username and password in the db and verify it. current constraint explained in owner-routes.js.
+router.post('/login', async (req, res) => {
+  try {
+    const walkerUserNameData = await Owner.findOne({
+      where: { user_name: req.body.user_name },
+    });
+    if (!walkerUserNameData) {
+      res.status(400).json({ message: 'No dog walker with that username!' });
+      return;
+    }
+    // verify the user using checkPassword method defined in Owner model.
+    const validPassword = walkerUserNameData.checkPassword(req.body.password);
+    if (!validPassword) {
+      res.status(400).json({ message: 'Invalid password. Try again' });
+      return;
+    }
+    res.json({
+      user: walkerUserNameData,
+      message: `${walkerUserNameData.walker_name}, you are now logged in!`,
+    });
+  } catch (err) {
+    console.log(err);
+    res.status(500).json(err);
+  }
+});
 
 // PUT api/walkers/:id updating a walker's info based on its id.
 router.put('/:id', async (req, res) => {


### PR DESCRIPTION
login route for both owner and walker created.

Tested it through insomnia. It doesn't work with the seed data. 
In order to test it,  you need to create a new user and after that test the /login route. 

I believe it doesn't work with seed data because when you seed the password(s) don't go through the bcrypt npm hashing process. I don't think it is a big deal since in production environment, user will always sign up. I will look further into how I can hook it as seed file gets ingested. 